### PR TITLE
Use asyncio.timeout/async_timeout to avoid creating tasks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-cov pytest-asyncio
+        python -m pip install flake8 pytest pytest-cov pytest-asyncio async_timeout
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/screenlogicpy/requests/request.py
+++ b/screenlogicpy/requests/request.py
@@ -1,20 +1,20 @@
 import asyncio
 
-from .protocol import ScreenLogicProtocol
 from ..const import MESSAGE, ScreenLogicWarning
+from .protocol import ScreenLogicProtocol
+from .utility import asyncio_timeout
 
 
 async def async_make_request(
     protocol: ScreenLogicProtocol, messageCode: int, message: bytes = b""
 ) -> bytes:
+    request = protocol.await_send_message(messageCode, message)
     try:
-        await asyncio.wait_for(
-            (request := protocol.await_send_message(messageCode, message)),
-            MESSAGE.COM_TIMEOUT,
-        )
-        if not request.cancelled():
-            return request.result()
+        async with asyncio_timeout(MESSAGE.COM_TIMEOUT):
+            await request
     except asyncio.TimeoutError:
         raise ScreenLogicWarning(
             f"Timeout waiting for response to message code '{messageCode}'"
         )
+    if not request.cancelled():
+        return request.result()

--- a/screenlogicpy/requests/utility.py
+++ b/screenlogicpy/requests/utility.py
@@ -1,7 +1,13 @@
 import struct
+import sys
 from typing import List, Tuple
 
-from ..const import CODE, DATA, MESSAGE, ScreenLogicError, UNIT
+from ..const import CODE, DATA, MESSAGE, UNIT, ScreenLogicError
+
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout
+else:
+    from asyncio import timeout as asyncio_timeout
 
 
 def makeMessage(msgID: int, msgCode: int, messageData: bytes = b""):

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,8 @@ setuptools.setup(
         "Development Status :: 3 - Alpha",
     ],
     python_requires=">=3.8",
+    install_requires=[
+        "async_timeout>=3.0.0",
+    ],
     entry_points={"console_scripts": ["screenlogicpy=screenlogicpy.__main__:main"]},
 )


### PR DESCRIPTION
py3.11 has a new `asyncio.timeout` which is much more efficient.

We can use `async_timeout` on < py3.11