### PR TITLE
Use constants for measurement units

### DIFF
--- a/notes/12576_set_scg.txt
+++ b/notes/12576_set_scg.txt
@@ -1,0 +1,7 @@
+00 00 20 31 14 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 00 00 00
+ID   |Code |Size       |ctrlIdx    |PoolPct    |SpaPct     |SupChlor   |Hours
+0    |12576|20         |0          |0          |0          |1          |           
+
+00 00 20 31 14 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 03 00 00 00
+ID   |Code |Size       |ctrlIdx    |PoolPct    |SpaPct     |SupChlor   |SupChlorHrs
+0    |12576|20         |0          |0          |0          |1          |3           

--- a/screenlogicpy/const.py
+++ b/screenlogicpy/const.py
@@ -187,8 +187,32 @@ class DEVICE_TYPE:
 
 
 class UNIT:
+    # Chemistry
+    PARTS_PER_MILLION = "ppm"
+    PERCENT = "%"
+    PH = "pH"
+    SATURATION_INDEX = "lsi"
+
+    # Electrical
+    MILLIVOLT = "mV"
+    WATT = "W"
+
+    # Flow
+    GALLONS_PER_MINUTE = "gpm"
+
+    # Speed
+    REVOLUTIONS_PER_MINUTE = "rpm"
+
+    # Temperature
     CELSIUS = "\xb0C"
     FAHRENHEIT = "\xb0F"
+
+    # Time
+    HOUR = "hr"
+    SECOND = "sec"
+
+    # Volume
+    MILLILITER = "mL"
 
 
 class EQUIPMENT:
@@ -294,6 +318,7 @@ class CHEM_DOSING_STATE:
 
 class SCG:
     LIMIT_FOR_BODY = {BODY_TYPE.POOL: 100, BODY_TYPE.SPA: 100}
+    MAX_SC_RUNTIME = 72
 
 
 GENERIC_CIRCUIT_NAMES = [

--- a/screenlogicpy/requests/chemistry.py
+++ b/screenlogicpy/requests/chemistry.py
@@ -60,7 +60,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["ph_last_dose_time"] = {
         "name": "Last pH Dose Time",
         "value": pHDoseTime,
-        "unit": "Sec",
+        "unit": "Seconds",
         "device_type": DEVICE_TYPE.DURATION,
     }
 
@@ -68,7 +68,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["orp_last_dose_time"] = {
         "name": "Last ORP Dose Time",
         "value": orpDoseTime,
-        "unit": "Sec",
+        "unit": "Seconds",
         "device_type": DEVICE_TYPE.DURATION,
     }
 

--- a/screenlogicpy/requests/chemistry.py
+++ b/screenlogicpy/requests/chemistry.py
@@ -60,7 +60,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["ph_last_dose_time"] = {
         "name": "Last pH Dose Time",
         "value": pHDoseTime,
-        "unit": "seconds",
+        "unit": "s",
         "device_type": DEVICE_TYPE.DURATION,
     }
 
@@ -68,7 +68,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["orp_last_dose_time"] = {
         "name": "Last ORP Dose Time",
         "value": orpDoseTime,
-        "unit": "seconds",
+        "unit": "s",
         "device_type": DEVICE_TYPE.DURATION,
     }
 

--- a/screenlogicpy/requests/chemistry.py
+++ b/screenlogicpy/requests/chemistry.py
@@ -7,6 +7,7 @@ from ..const import (
     DATA,
     DEVICE_TYPE,
     ON_OFF,
+    UNIT,
 )
 from .protocol import ScreenLogicProtocol
 from .request import async_make_request
@@ -37,30 +38,38 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry[f"unknown_at_offset_{offset:02}"], offset = getSome("B", buff, offset)
 
     pH, offset = getSome(">H", buff, offset)  # 1
-    chemistry["current_ph"] = {"name": "Current pH", "value": (pH / 100), "unit": "pH"}
+    chemistry["current_ph"] = {
+        "name": "Current pH",
+        "value": (pH / 100),
+        "unit": UNIT.PH,
+    }
 
     orp, offset = getSome(">H", buff, offset)  # 3
-    chemistry["current_orp"] = {"name": "Current ORP", "value": orp, "unit": "mV"}
+    chemistry["current_orp"] = {
+        "name": "Current ORP",
+        "value": orp,
+        "unit": UNIT.MILLIVOLT,
+    }
 
     pHSetpoint, offset = getSome(">H", buff, offset)  # 5
     chemistry["ph_setpoint"] = {
         "name": "pH Setpoint",
         "value": (pHSetpoint / 100),
-        "unit": "pH",
+        "unit": UNIT.PH,
     }
 
     orpSetpoint, offset = getSome(">H", buff, offset)  # 7
     chemistry["orp_setpoint"] = {
         "name": "ORP Setpoint",
         "value": orpSetpoint,
-        "unit": "mV",
+        "unit": UNIT.MILLIVOLT,
     }
 
     pHDoseTime, offset = getSome(">I", buff, offset)  # 9
     chemistry["ph_last_dose_time"] = {
         "name": "Last pH Dose Time",
         "value": pHDoseTime,
-        "unit": "s",
+        "unit": UNIT.SECOND,
         "device_type": DEVICE_TYPE.DURATION,
     }
 
@@ -68,7 +77,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["orp_last_dose_time"] = {
         "name": "Last ORP Dose Time",
         "value": orpDoseTime,
-        "unit": "s",
+        "unit": UNIT.SECOND,
         "device_type": DEVICE_TYPE.DURATION,
     }
 
@@ -76,7 +85,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["ph_last_dose_volume"] = {
         "name": "Last pH Dose Volume",
         "value": pHDoseVolume,
-        "unit": "mL",
+        "unit": UNIT.MILLILITER,
         "device_type": DEVICE_TYPE.VOLUME,
     }
 
@@ -84,7 +93,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["orp_last_dose_volume"] = {
         "name": "Last ORP Dose Volume",
         "value": orpDoseVolume,
-        "unit": "mL",
+        "unit": UNIT.MILLILITER,
         "device_type": DEVICE_TYPE.VOLUME,
     }
 
@@ -103,14 +112,14 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
         "value": (saturation - 256) / 100
         if is_set(saturation, 0x80)
         else saturation / 100,
-        "unit": "lsi",
+        "unit": UNIT.SATURATION_INDEX,
     }
 
     cal, offset = getSome(">H", buff, offset)  # 24
     chemistry["calcium_harness"] = {
         "name": "Calcium Hardness",
         "value": cal,
-        "unit": "ppm",
+        "unit": UNIT.PARTS_PER_MILLION,
     }
 
     cya, offset = getSome(">H", buff, offset)  # 26
@@ -120,14 +129,14 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["total_alkalinity"] = {
         "name": "Total Alkalinity",
         "value": alk,
-        "unit": "ppm",
+        "unit": UNIT.PARTS_PER_MILLION,
     }
 
     saltPPM, offset = getSome("B", buff, offset)  # 30
     chemistry["salt_tds_ppm"] = {
         "name": "Salt/TDS",
         "value": (saltPPM * 50),
-        "unit": "ppm",
+        "unit": UNIT.PARTS_PER_MILLION,
     }
 
     # Probe temp unit is Celsius?

--- a/screenlogicpy/requests/chemistry.py
+++ b/screenlogicpy/requests/chemistry.py
@@ -60,7 +60,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["ph_last_dose_time"] = {
         "name": "Last pH Dose Time",
         "value": pHDoseTime,
-        "unit": "Seconds",
+        "unit": "seconds",
         "device_type": DEVICE_TYPE.DURATION,
     }
 
@@ -68,7 +68,7 @@ def decode_chemistry(buff: bytes, data: dict) -> None:
     chemistry["orp_last_dose_time"] = {
         "name": "Last ORP Dose Time",
         "value": orpDoseTime,
-        "unit": "Seconds",
+        "unit": "seconds",
         "device_type": DEVICE_TYPE.DURATION,
     }
 

--- a/screenlogicpy/requests/pump.py
+++ b/screenlogicpy/requests/pump.py
@@ -1,6 +1,6 @@
 import struct
 
-from ..const import CODE, DATA, DEVICE_TYPE
+from ..const import CODE, DATA, DEVICE_TYPE, UNIT
 from .protocol import ScreenLogicProtocol
 from .request import async_make_request
 from .utility import getSome
@@ -62,7 +62,7 @@ def decode_pump_status(buff: bytes, data: dict, pumpID: int) -> None:
         pump["currentWatts"] = {
             "name": pump["name"] + " Current Watts",
             "value": curW,
-            "unit": "W",
+            "unit": UNIT.WATT,
             "device_type": DEVICE_TYPE.POWER,
         }
 
@@ -70,12 +70,12 @@ def decode_pump_status(buff: bytes, data: dict, pumpID: int) -> None:
         pump["currentRPM"] = {
             "name": pump["name"] + " Current RPM",
             "value": curR,
-            "unit": "rpm",
+            "unit": UNIT.REVOLUTIONS_PER_MINUTE,
         }
 
     if "currentGPM" in pump:
         pump["currentGPM"] = {
             "name": pump["name"] + " Current GPM",
             "value": curG,
-            "unit": "gpm",
+            "unit": UNIT.GALLONS_PER_MINUTE,
         }

--- a/screenlogicpy/requests/scg.py
+++ b/screenlogicpy/requests/scg.py
@@ -1,6 +1,6 @@
 import struct
 
-from ..const import CODE, DATA
+from ..const import CODE, DATA, UNIT
 from .protocol import ScreenLogicProtocol
 from .request import async_make_request
 from .utility import getSome
@@ -21,16 +21,31 @@ def decode_scg_config(buff: bytes, data: dict) -> None:
     scg["scg_present"] = present
 
     status, offset = getSome("I", buff, offset)
-    scg["scg_status"] = {"name": "SCG Status", "value": status}
+    scg["scg_status"] = {
+        "name": "SCG Status",
+        "value": status,
+    }
 
     level1, offset = getSome("I", buff, offset)
-    scg["scg_level1"] = {"name": "Pool SCG Level", "value": level1, "unit": "%"}
+    scg["scg_level1"] = {
+        "name": "Pool SCG Level",
+        "value": level1,
+        "unit": UNIT.PERCENT,
+    }
 
     level2, offset = getSome("I", buff, offset)
-    scg["scg_level2"] = {"name": "Spa SCG Level", "value": level2, "unit": "%"}
+    scg["scg_level2"] = {
+        "name": "Spa SCG Level",
+        "value": level2,
+        "unit": UNIT.PERCENT,
+    }
 
     salt, offset = getSome("I", buff, offset)
-    scg["scg_salt_ppm"] = {"name": "SCG Salt", "value": (salt * 50), "unit": "ppm"}
+    scg["scg_salt_ppm"] = {
+        "name": "SCG Salt",
+        "value": (salt * 50),
+        "unit": UNIT.PARTS_PER_MILLION,
+    }
 
     flags, offset = getSome("I", buff, offset)
     scg["scg_flags"] = flags
@@ -39,17 +54,22 @@ def decode_scg_config(buff: bytes, data: dict) -> None:
     scg["scg_super_chlor_timer"] = {
         "name": "SCG Super Chlorination Timer",
         "value": superChlorTimer,
+        "unit": UNIT.HOUR,
     }
 
 
 async def async_request_set_scg_config(
-    protocol: ScreenLogicProtocol, pool_output: int, spa_output: int
+    protocol: ScreenLogicProtocol,
+    pool_output: int,
+    spa_output: int,
+    super_chlor: int = 0,
+    super_time: int = 0,
 ) -> bool:
     return (
         await async_make_request(
             protocol,
             CODE.SETSCG_QUERY,
-            struct.pack("<IIIII", 0, pool_output, spa_output, 0, 0),
+            struct.pack("<IIIII", 0, pool_output, spa_output, super_chlor, super_time),
         )
         == b""
     )

--- a/screenlogicpy/requests/status.py
+++ b/screenlogicpy/requests/status.py
@@ -6,6 +6,7 @@ from ..const import (
     BODY_TYPE,
     DATA,
     DEVICE_TYPE,
+    UNIT,
 )
 from .protocol import ScreenLogicProtocol
 from .request import async_make_request
@@ -109,7 +110,10 @@ def decode_pool_status(buff: bytes, data: dict) -> None:
 
         heatMode, offset = getSome("i", buff, offset)
         hmName = "{} Heat Mode".format(BODY_TYPE.NAME_FOR_NUM[bodyType])
-        currentBody["heat_mode"] = {"name": hmName, "value": heatMode}
+        currentBody["heat_mode"] = {
+            "name": hmName,
+            "value": heatMode,
+        }
 
     circuitCount, offset = getSome("I", buff, offset)
 
@@ -139,26 +143,44 @@ def decode_pool_status(buff: bytes, data: dict) -> None:
         currentCircuit["delay"] = circuitDelay
 
     pH, offset = getSome("i", buff, offset)
-    sensors["ph"] = {"name": "pH", "value": (pH / 100), "unit": "pH"}
+    sensors["ph"] = {
+        "name": "pH",
+        "value": (pH / 100),
+        "unit": UNIT.PH,
+    }
 
     orp, offset = getSome("i", buff, offset)
-    sensors["orp"] = {"name": "ORP", "value": orp, "unit": "mV"}
+    sensors["orp"] = {
+        "name": "ORP",
+        "value": orp,
+        "unit": UNIT.MILLIVOLT,
+    }
 
     saturation, offset = getSome("i", buff, offset)
     sensors["saturation"] = {
         "name": "Saturation Index",
         "value": (saturation / 100),
-        "unit": "lsi",
+        "unit": UNIT.SATURATION_INDEX,
     }
 
     saltPPM, offset = getSome("i", buff, offset)
-    sensors["salt_ppm"] = {"name": "Salt", "value": (saltPPM * 50), "unit": "ppm"}
+    sensors["salt_ppm"] = {
+        "name": "Salt",
+        "value": (saltPPM * 50),
+        "unit": UNIT.PARTS_PER_MILLION,
+    }
 
     pHTank, offset = getSome("i", buff, offset)
-    sensors["ph_supply_level"] = {"name": "pH Supply Level", "value": pHTank}
+    sensors["ph_supply_level"] = {
+        "name": "pH Supply Level",
+        "value": pHTank,
+    }
 
     orpTank, offset = getSome("i", buff, offset)
-    sensors["orp_supply_level"] = {"name": "ORP Supply Level", "value": orpTank}
+    sensors["orp_supply_level"] = {
+        "name": "ORP Supply Level",
+        "value": orpTank,
+    }
 
     alarm, offset = getSome("i", buff, offset)
     sensors["chem_alarm"] = {

--- a/tests/const_data.py
+++ b/tests/const_data.py
@@ -664,13 +664,13 @@ EXPECTED_CHEMISTRY_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "Sec",
+            "unit": "Seconds",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "Sec",
+            "unit": "Seconds",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {
@@ -1230,13 +1230,13 @@ EXPECTED_COMPLETE_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "Sec",
+            "unit": "Seconds",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "Sec",
+            "unit": "Seconds",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {

--- a/tests/const_data.py
+++ b/tests/const_data.py
@@ -664,13 +664,13 @@ EXPECTED_CHEMISTRY_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "s",
+            "unit": "sec",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "s",
+            "unit": "sec",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {
@@ -747,7 +747,11 @@ EXPECTED_SCG_DATA = {
         "scg_level2": {"name": "Spa SCG Level", "value": 0, "unit": "%"},
         "scg_salt_ppm": {"name": "SCG Salt", "value": 0, "unit": "ppm"},
         "scg_flags": 0,
-        "scg_super_chlor_timer": {"name": "SCG Super Chlorination Timer", "value": 0},
+        "scg_super_chlor_timer": {
+            "name": "SCG Super Chlorination Timer",
+            "value": 0,
+            "unit": "hr",
+        },
     }
 }
 
@@ -1230,13 +1234,13 @@ EXPECTED_COMPLETE_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "s",
+            "unit": "sec",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "s",
+            "unit": "sec",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {
@@ -1310,7 +1314,11 @@ EXPECTED_COMPLETE_DATA = {
         "scg_level2": {"name": "Spa SCG Level", "value": 0, "unit": "%"},
         "scg_salt_ppm": {"name": "SCG Salt", "value": 0, "unit": "ppm"},
         "scg_flags": 0,
-        "scg_super_chlor_timer": {"name": "SCG Super Chlorination Timer", "value": 0},
+        "scg_super_chlor_timer": {
+            "name": "SCG Super Chlorination Timer",
+            "value": 0,
+            "unit": "hr",
+        },
     },
 }
 

--- a/tests/const_data.py
+++ b/tests/const_data.py
@@ -664,13 +664,13 @@ EXPECTED_CHEMISTRY_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "seconds",
+            "unit": "s",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "seconds",
+            "unit": "s",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {
@@ -1230,13 +1230,13 @@ EXPECTED_COMPLETE_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "seconds",
+            "unit": "s",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "seconds",
+            "unit": "s",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {

--- a/tests/const_data.py
+++ b/tests/const_data.py
@@ -664,13 +664,13 @@ EXPECTED_CHEMISTRY_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "Seconds",
+            "unit": "seconds",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "Seconds",
+            "unit": "seconds",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {
@@ -1230,13 +1230,13 @@ EXPECTED_COMPLETE_DATA = {
         "ph_last_dose_time": {
             "name": "Last pH Dose Time",
             "value": 5,
-            "unit": "Seconds",
+            "unit": "seconds",
             "device_type": "duration",
         },
         "orp_last_dose_time": {
             "name": "Last ORP Dose Time",
             "value": 2,
-            "unit": "Seconds",
+            "unit": "seconds",
             "device_type": "duration",
         },
         "ph_last_dose_volume": {


### PR DESCRIPTION
Use constants for measurement units to support translation in consuming apps.
Some additional prep work to support setting super chlorinate.