### PR TITLE
Variable CLIENT_ID

### DIFF
--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -40,14 +40,12 @@ _LOGGER = logging.getLogger(__name__)
 class ScreenLogicGateway:
     """Class for interacting and communicating with a ScreenLogic protocol adapter."""
 
-    def __init__(
-        self, ip=None, port=80, gtype=0, gsubtype=0, name="Unnamed-Screenlogic-Gateway"
-    ):
-        self._ip = ip
-        self._port = port
-        self._type = gtype
-        self._subtype = gsubtype
-        self._name = name
+    def __init__(self, client_id: int = None):
+        self._ip = None
+        self._port = 80
+        self._type = 0
+        self._subtype = 0
+        self._name = "Unnamed-Screenlogic-Gateway"
         self._mac = ""
         self._version = ""
         self._transport: asyncio.Transport = None
@@ -55,8 +53,8 @@ class ScreenLogicGateway:
         self._is_client = False
         self._data = {}
         self._last = {}
-        self._client_manager = ClientManager()
         self._max_retries = MESSAGE.COM_MAX_RETRIES
+        self._client_manager = ClientManager(client_id)
 
     @property
     def ip(self) -> str:
@@ -85,6 +83,10 @@ class ScreenLogicGateway:
     @property
     def is_client(self) -> bool:
         return self._client_manager.is_client
+
+    @property
+    def client_id(self) -> int:
+        return self._client_manager.client_id
 
     @property
     def max_retries(self) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,8 @@ async def FailingMockProtocolAdapter(event_loop: asyncio.AbstractEventLoop):
 @pytest_asyncio.fixture()
 async def MockConnectedGateway(MockProtocolAdapter):
     async with MockProtocolAdapter:
-        gateway = ScreenLogicGateway(**FAKE_CONNECT_INFO)
-        await gateway.async_connect()
+        gateway = ScreenLogicGateway()
+        await gateway.async_connect(**FAKE_CONNECT_INFO)
         assert gateway.is_connected
         await gateway.async_update()
         yield gateway

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,12 @@
 import asyncio
+import pytest
+import random
 import struct
 from unittest.mock import patch
 
-import pytest
-
 from screenlogicpy import ScreenLogicGateway
 from screenlogicpy.client import ClientManager
-from screenlogicpy.const import CLIENT_ID, CODE
-
+from screenlogicpy.const import CODE
 from .const_data import (
     EXPECTED_CHEMISTRY_DATA,
     EXPECTED_STATUS_DATA,
@@ -21,9 +20,9 @@ from .fake_gateway import expected_resp
 @pytest.mark.asyncio()
 async def test_sub_unsub(event_loop, MockProtocolAdapter):
     async with MockProtocolAdapter:
-        gateway = ScreenLogicGateway()
+        clientID = random.randint(32767, 65535)
+        gateway = ScreenLogicGateway(clientID)
         code = CODE.STATUS_CHANGED
-        clientID = CLIENT_ID
 
         def callback():
             pass

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -42,15 +42,8 @@ async def test_gateway(MockConnectedGateway):
 @pytest.mark.asyncio
 async def test_gateway_connect(MockProtocolAdapter):
     async with MockProtocolAdapter:
-        gateway = ScreenLogicGateway(**FAKE_CONNECT_INFO)
-        await gateway.async_connect()
-        assert gateway.ip == FAKE_GATEWAY_ADDRESS
-        assert gateway.port == FAKE_GATEWAY_PORT
-        assert gateway.name == FAKE_GATEWAY_NAME
-        assert gateway.version == FAKE_GATEWAY_VERSION
-        assert gateway.mac == FAKE_GATEWAY_MAC
-        assert gateway.is_connected
-        await gateway.async_disconnect()
+        with pytest.raises(TypeError):
+            _ = ScreenLogicGateway(**FAKE_CONNECT_INFO)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Support a variable CLIENT_ID.
- Specify specific ID (unique to instance) at `ScreenLogicGateway` instantiation.
- If not specified, use a random int in the upper half of an unsigned short (32767-65535)