### PR TITLE
Support reconnect attempt on request failure

### DIFF
--- a/notes/equip_flags.txt
+++ b/notes/equip_flags.txt
@@ -1,44 +1,28 @@
-0D-BF-7F                                11 1100
-0D-C6-A5                                 1 1100
-0D-CD-0C                                 1 1000
-0F-5A-03                                11 1000
-config	1111 1111 1111 1111 1000 0000 0011 1000
-solar	                                   0001
-sheatp	                                   0010
-chlor	                                   0100
-UNKNOWN                                    1000
-UNKNOWN                                  1 0000
-sparmt                                  10 0000
-cooling	                         1000 0000 0000
-ichem	                    1000 0000 0000 0000
+7F                                      11 1100  IntelliTouch i5+3S
+A5                                       1 1100  IntelliTouch i5+3S
+0C                                       1 1000  IntelliTouch i5+3S
+03                                      11 1000  IntelliTouch i7+3
+                                      0011 0000  IntelliTouch i9+3
+                            0010 0000 0001 1111
+config	1111 1111 1111 1111 1000 0000 0011 1000  EasyTouch2 8
 
+solar	                                   0001
+solar as heat pump                         0010
+chlorinator                                0100
+UNKNOWN                                    1000
+UNKNOWN                               0001 0000
+spa remote                            0010 0000
+UNKNOWN                               0100 0000
+UNKNOWN                               1000 0000
+UNKNOWN                          0001 0000 0000
+UNKNOWN                          0010 0000 0000
+UNKNOWN                          0100 0000 0000
+(Night?) cooling                 1000 0000 0000
+UNKNOWN                     0001 0000 0000 0000
+UNKNOWN                     0010 0000 0000 0000
+UNKNOWN                     0100 0000 0000 0000
+IntelliChem                 1000 0000 0000 0000
+
+Pump Data
 pump 0  0100 0110
 pump 1  0100 0010
-
-
-SERVICE
-"controller_buffer": 1,
-"show_alarms": 1,
-"ok": 3,
-"freeze_mode": {
-    "name": "Freeze Mode",
-    "value": 0
-},
-
-SERVICE_TIMEOUT
-"controller_buffer": 129,
-"show_alarms": 1,
-"ok": 3,
-"freeze_mode": {
-    "name": "Freeze Mode",
-    "value": 0
-},
-
-AUTO
-"controller_buffer": 0,
-"show_alarms": 1,
-"ok": 1,
-"freeze_mode": {
-    "name": "Freeze Mode",
-    "value": 0
-},

--- a/screenlogicpy/__init__.py
+++ b/screenlogicpy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 # flake8: noqa F401
 from screenlogicpy.gateway import ScreenLogicGateway
 from screenlogicpy.const import ScreenLogicError, ScreenLogicRequestError

--- a/screenlogicpy/__init__.py
+++ b/screenlogicpy/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.8.1"
 # flake8: noqa F401
 from screenlogicpy.gateway import ScreenLogicGateway
-from screenlogicpy.const import ScreenLogicError
+from screenlogicpy.const import ScreenLogicError, ScreenLogicRequestError
 from screenlogicpy.discovery import async_discover

--- a/screenlogicpy/client.py
+++ b/screenlogicpy/client.py
@@ -9,7 +9,6 @@ from .const import (
     COM_KEEPALIVE,
     MESSAGE,
     ScreenLogicRequestError,
-    ScreenLogicWarning,
 )
 from .requests import (
     async_request_add_client,
@@ -170,14 +169,10 @@ class ClientManager:
 
     async def _async_remove_client(self):
         """Check connection before sending remove client request."""
-        if not self._attached():
-            raise ScreenLogicWarning(
-                "Attempted to remove_client but not attached to protocol adapter"
-            )
         _LOGGER.debug("Requesting remove client")
         try:
             return await async_request_remove_client(
-                self._protocol, self._client_id, max_retries=self._max_retries
+                self._protocol, self._client_id, max_retries=0
             )
         except ScreenLogicRequestError:
             return False

--- a/screenlogicpy/client.py
+++ b/screenlogicpy/client.py
@@ -2,14 +2,23 @@
 import asyncio
 import logging
 import random
-from typing import Callable
+from typing import Awaitable, Callable
 
-from .const import CODE, COM_KEEPALIVE, MESSAGE, ScreenLogicWarning
+from .const import (
+    CODE,
+    COM_KEEPALIVE,
+    MESSAGE,
+    ScreenLogicRequestError,
+    ScreenLogicWarning,
+)
+from .requests import (
+    async_request_add_client,
+    async_request_ping,
+    async_request_remove_client,
+)
 from .requests.chemistry import decode_chemistry
-from .requests.client import async_request_add_client, async_request_remove_client
 from .requests.lights import decode_color_update
 from .requests.status import decode_pool_status
-from .requests.ping import async_request_ping
 from .requests.protocol import ScreenLogicProtocol
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,7 +27,12 @@ _LOGGER = logging.getLogger(__name__)
 class ClientManager:
     """Class to manage callback subscriptions to specific ScreenLogic messages."""
 
-    def __init__(self, client_id: int = None) -> None:
+    def __init__(
+        self,
+        async_request_manager: Callable[[bytes, any], Awaitable[any]],
+        client_id: int = None,
+    ) -> None:
+        self._async_managed_request = async_request_manager
         self._client_id = (
             client_id if client_id is not None else random.randint(32767, 65535)
         )
@@ -143,35 +157,30 @@ class ClientManager:
 
     async def _async_ping(self):
         """Check connection before requesting a ping."""
-        if not self._attached():
-            raise ScreenLogicWarning(
-                "Not attached to protocol adapter. request_ping failed."
-            )
         _LOGGER.debug("Requesting ping")
-        if await async_request_ping(self._protocol, max_retries=self._max_retries):
+        if await self._async_managed_request(async_request_ping):
             _LOGGER.debug("Ping successful.")
 
     async def _async_add_client(self):
         """Check connection before sending add client request."""
-        if not self._attached():
-            raise ScreenLogicWarning(
-                "Not attached to protocol adapter. add_client failed."
-            )
         _LOGGER.debug("Requesting add client")
-        return await async_request_add_client(
-            self._protocol, self._client_id, max_retries=self._max_retries
+        return await self._async_managed_request(
+            async_request_add_client, self._client_id
         )
 
     async def _async_remove_client(self):
         """Check connection before sending remove client request."""
         if not self._attached():
             raise ScreenLogicWarning(
-                "Not attached to protocol adapter. remove_client failed."
+                "Attempted to remove_client but not attached to protocol adapter"
             )
         _LOGGER.debug("Requesting remove client")
-        return await async_request_remove_client(
-            self._protocol, self._client_id, max_retries=self._max_retries
-        )
+        try:
+            return await async_request_remove_client(
+                self._protocol, self._client_id, max_retries=self._max_retries
+            )
+        except ScreenLogicRequestError:
+            return False
 
     async def async_subscribe_gateway(self) -> bool:
         """

--- a/screenlogicpy/const.py
+++ b/screenlogicpy/const.py
@@ -26,10 +26,6 @@ class ScreenLogicError(ScreenLogicException):
     pass
 
 
-class ScreenLogicRequestTimeout(ScreenLogicException):
-    pass
-
-
 class ScreenLogicRequestError(ScreenLogicException):
     pass
 

--- a/screenlogicpy/const.py
+++ b/screenlogicpy/const.py
@@ -15,7 +15,11 @@ SL_GATEWAY_NAME = "name"
 
 
 class ScreenLogicException(Exception):
-    pass
+    """Common class for all ScreenLogic exceptions."""
+
+    def __init__(self, message: str, *args: object) -> None:
+        self.msg = message
+        super().__init__(*args)
 
 
 class ScreenLogicWarning(ScreenLogicException):

--- a/screenlogicpy/const.py
+++ b/screenlogicpy/const.py
@@ -14,18 +14,30 @@ SL_GATEWAY_SUBTYPE = "gsubtype"
 SL_GATEWAY_NAME = "name"
 
 
-class ScreenLogicError(Exception):
+class ScreenLogicException(Exception):
     pass
 
 
-class ScreenLogicWarning(Exception):
+class ScreenLogicWarning(ScreenLogicException):
+    pass
+
+
+class ScreenLogicError(ScreenLogicException):
+    pass
+
+
+class ScreenLogicRequestTimeout(ScreenLogicException):
+    pass
+
+
+class ScreenLogicRequestError(ScreenLogicException):
     pass
 
 
 class MESSAGE:
-    COM_MAX_RETRIES = 2
-    COM_RETRY_WAIT = 2
-    COM_TIMEOUT = 5
+    COM_MAX_RETRIES = 1
+    COM_RETRY_WAIT = 1
+    COM_TIMEOUT = 2
     HEADER_FORMAT = "<HHI"
     HEADER_LENGTH = struct.calcsize(HEADER_FORMAT)
 

--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -369,10 +369,13 @@ class ScreenLogicGateway:
         try:
             return await attempt_request()
         except ScreenLogicRequestError as re:
-            _LOGGER.debug("%s. Attempting to reconnect", re.args[0])
+            _LOGGER.debug("%s. Attempting to reconnect", re.msg)
             await self.async_disconnect(True)
             await asyncio.sleep(reconnect_delay)
-            return await attempt_request()
+            try:
+                return await attempt_request()
+            except ScreenLogicRequestError as re2:
+                raise ScreenLogicError(re2.msg) from re2
 
     def _common_connection_closed_callback(self):
         """Perform any needed cleanup."""

--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -367,7 +367,7 @@ class ScreenLogicGateway:
         try:
             return await attempt_request()
         except ScreenLogicRequestError as re:
-            _LOGGER.warning("%s. Attempting to reconnect", re.args[0])
+            _LOGGER.debug("%s. Attempting to reconnect", re.args[0])
             await self.async_disconnect(True)
             return await attempt_request()
 

--- a/screenlogicpy/requests/__init__.py
+++ b/screenlogicpy/requests/__init__.py
@@ -1,5 +1,7 @@
 # flake8: noqa F401
 from .button import async_request_pool_button_press
+from .chemistry import async_request_chemistry, async_request_set_chem_data
+from .client import async_request_add_client, async_request_remove_client
 from .config import async_request_pool_config
 from .equipment import async_request_equipment_config
 from .gateway import async_request_gateway_version
@@ -9,6 +11,5 @@ from .login import async_connect_to_gateway
 from .ping import async_request_ping
 from .pump import async_request_pump_status
 from .status import async_request_pool_status
-from .chemistry import async_request_chemistry, async_request_set_chem_data
 from .scg import async_request_scg_config, async_request_set_scg_config
 from .request import async_make_request

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -3,7 +3,7 @@ import logging
 import struct
 from typing import Callable, Tuple
 
-from ..const import CODE, MESSAGE, ScreenLogicError, ScreenLogicWarning
+from ..const import CODE, MESSAGE, ScreenLogicError, ScreenLogicRequestError
 from .protocol import ScreenLogicProtocol
 from .request import async_make_request
 from .utility import asyncio_timeout, decodeMessageString, encodeMessageString
@@ -90,10 +90,10 @@ async def async_gateway_connect(
                 protocol, CODE.CHALLENGE_QUERY, max_retries=max_retries
             )
         )
-    except ScreenLogicWarning as warn:
+    except ScreenLogicRequestError as re:
         raise ScreenLogicError(
-            f"Host failed to respond to challenge: : {warn.args[0]}"
-        ) from warn
+            f"Host failed to respond to challenge: : {re.args[0]}"
+        ) from re
 
 
 async def async_gateway_login(protocol: ScreenLogicProtocol, max_retries: int) -> bool:
@@ -105,8 +105,8 @@ async def async_gateway_login(protocol: ScreenLogicProtocol, max_retries: int) -
             )
             is not None
         )
-    except ScreenLogicWarning as warn:
-        raise ScreenLogicError(f"Failed to logon to gateway: {warn.args[0]}") from warn
+    except ScreenLogicRequestError as re:
+        raise ScreenLogicError(f"Failed to logon to gateway: {re.args[0]}") from re
 
 
 async def async_connect_to_gateway(

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -92,7 +92,7 @@ async def async_gateway_connect(
         )
     except ScreenLogicRequestError as re:
         raise ScreenLogicError(
-            f"Host failed to respond to challenge: : {re.args[0]}"
+            f"Host failed to respond to challenge: : {re.msg}"
         ) from re
 
 
@@ -106,7 +106,7 @@ async def async_gateway_login(protocol: ScreenLogicProtocol, max_retries: int) -
             is not None
         )
     except ScreenLogicRequestError as re:
-        raise ScreenLogicError(f"Failed to logon to gateway: {re.args[0]}") from re
+        raise ScreenLogicError(f"Failed to logon to gateway: {re.msg}") from re
 
 
 async def async_connect_to_gateway(

--- a/screenlogicpy/requests/protocol.py
+++ b/screenlogicpy/requests/protocol.py
@@ -21,6 +21,7 @@ class ScreenLogicProtocol(asyncio.Protocol):
         self._futures = self.FutureManager(self._loop)
         self._callbacks = {}
         self._connected = False
+        self._closing = False
         self._last_request: float = None
         self._last_response: float = None
         self._buff = bytearray()
@@ -38,6 +39,10 @@ class ScreenLogicProtocol(asyncio.Protocol):
         """Return if protocol is currently connected."""
         return self._connected
 
+    @property
+    def is_closing(self):
+        return self._closing
+    
     @property
     def last_request(self):
         """Monotonic time for the last message sent."""
@@ -129,6 +134,9 @@ class ScreenLogicProtocol(asyncio.Protocol):
         if self._connection_lost_callback is not None:
             self._connection_lost_callback()
 
+    def close(self, force: bool = False):
+        self._closing = True
+        
     def register_async_message_callback(
         self,
         messageCode,

--- a/screenlogicpy/requests/request.py
+++ b/screenlogicpy/requests/request.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from ..const import CODE, MESSAGE, ScreenLogicWarning
+from ..const import CODE, MESSAGE, ScreenLogicRequestError
 from .protocol import ScreenLogicProtocol
 from .utility import asyncio_timeout
 
@@ -14,7 +14,7 @@ async def async_make_request(
     requestData: bytes = b"",
     max_retries: int = MESSAGE.COM_MAX_RETRIES,
 ) -> bytes:
-    for attempt in range(1, max_retries + 1):
+    for attempt in range(0, max_retries + 1):
         request = protocol.await_send_message(requestCode, requestData)
         try:
             async with asyncio_timeout(MESSAGE.COM_TIMEOUT):
@@ -41,11 +41,13 @@ async def async_make_request(
                 error_message = f"Unexpected response code '{responseCode}' for request code: {requestCode}, request: {requestData}"
 
         if attempt == max_retries:
-            raise ScreenLogicWarning(f"{error_message} after {max_retries} attempts")
+            raise ScreenLogicRequestError(
+                f"{error_message} after {max_retries} attempts"
+            )
 
-        retry_delay = MESSAGE.COM_RETRY_WAIT * attempt
+        retry_delay = MESSAGE.COM_RETRY_WAIT * (attempt + 1)
 
-        _LOGGER.debug(
+        _LOGGER.warning(
             error_message + ". Will retry %i more time(s) in %i seconds",
             max_retries - attempt,
             retry_delay,

--- a/screenlogicpy/requests/request.py
+++ b/screenlogicpy/requests/request.py
@@ -24,6 +24,7 @@ async def async_make_request(
                 f"Timeout waiting for response to message code '{requestCode}'"
             )
         except asyncio.CancelledError:
+            _LOGGER.debug(f"Future for request '{requestCode}' was canceled!")
             return
 
         if not request.cancelled():

--- a/screenlogicpy/requests/request.py
+++ b/screenlogicpy/requests/request.py
@@ -42,7 +42,7 @@ async def async_make_request(
 
         if attempt == max_retries:
             raise ScreenLogicRequestError(
-                f"{error_message} after {max_retries} attempts"
+                f"{error_message} after {max_retries + 1} attempts"
             )
 
         retry_delay = MESSAGE.COM_RETRY_WAIT * (attempt + 1)

--- a/screenlogicpy/requests/request.py
+++ b/screenlogicpy/requests/request.py
@@ -48,7 +48,7 @@ async def async_make_request(
 
         retry_delay = MESSAGE.COM_RETRY_WAIT * (attempt + 1)
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             error_message + ". Will retry %i more time(s) in %i seconds",
             max_retries - attempt,
             retry_delay,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="screenlogicpy",
-    version="0.8.1",
+    version="0.8.2",
     author="Kevin Worrel",
     author_email="kevinworrel@yahoo.com",
     description="Interface for Pentair ScreenLogic connected pool controllers over IP via Python",

--- a/tests/fake_gateway.py
+++ b/tests/fake_gateway.py
@@ -2,6 +2,7 @@
 import asyncio
 import random
 import struct
+import time
 from typing import List, Tuple
 
 from screenlogicpy.const import CODE, MESSAGE
@@ -77,6 +78,7 @@ class FakeScreenLogicTCPProtocol(asyncio.Protocol):
         return [self.process_message(message) for message in complete_messages(data)]
 
     def process_message(self, message: Tuple[int, int, bytes]) -> bytes:
+        time.sleep(0.1)
         messageID, messageCode, _ = message
         if (
             messageCode == CODE.CHALLENGE_QUERY
@@ -107,10 +109,12 @@ class FakeScreenLogicTCPProtocol(asyncio.Protocol):
 
 class FailingFakeScreenLogicTCPProtocol(FakeScreenLogicTCPProtocol):
     def process_message(self, message: Tuple[int, int, bytes]) -> bytes:
-        fail = random.randint(0, 5)
-        if fail > 3:
-            messageID, messageCode, _ = message
-            if fail == 4:
+        call_max = 75
+        messageID, messageCode, _ = message
+        call_min = messageID if messageID < call_max else call_max
+        fail = random.randint(call_min, call_max)
+        if fail > 68:
+            if fail > 72:
                 if messageCode == CODE.LOCALLOGIN_QUERY:
                     return makeMessage(messageID, CODE.ERROR_LOGIN_REJECTED)
                 else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,7 +98,7 @@ async def test_notify():
         nonlocal cb3_hit
         cb3_hit = True
 
-    cm = ClientManager()
+    cm = ClientManager(None)
     cm._listeners = {
         code1: {
             callback1,

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -150,7 +150,7 @@ async def test_async_set_circuit_timeout(
         with pytest.raises(ScreenLogicRequestError) as e_info:
             await gateway.async_set_circuit(circuit_id, circuit_state)
         await gateway.async_disconnect()
-        assert "Timeout" in e_info.value.args[0]
+        assert "Timeout" in e_info.value.msg
         assert mockRequest.call_count == 2
         assert mockRequest.call_args.args[0] == button_code
         assert mockRequest.call_args.args[1] == struct.pack(

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -66,7 +66,7 @@ async def test_async_login_timeout(
             gateway = ScreenLogicGateway()
             with pytest.raises(ScreenLogicError) as e_info:
                 await gateway.async_connect(**FAKE_CONNECT_INFO)
-            assert "Timeout" in e_info.value.args[0]
+            assert "Timeout" in e_info.value.msg
             assert mockRequest.call_count == 3
 
 
@@ -98,5 +98,5 @@ async def test_async_login_rejected(
             gateway = ScreenLogicGateway()
             with pytest.raises(ScreenLogicError) as e_info:
                 await gateway.async_connect(**FAKE_CONNECT_INFO)
-            assert "Rejected" in e_info.value.args[0]
+            assert "Rejected" in e_info.value.msg
             assert mockRequest.call_count == 3


### PR DESCRIPTION
Attempt to reconnect to the protocol adapter once after a failure to complete a request (for any reason) after retrying the set number of times. If reconnected, attempt the request again.
Raise full ScreenLogicError if reconnect or second full request attempt fails. This supports Home Assistant registering the failure and handling it accordingly.