### PR TITLE
Reset colors list on each config update

### DIFF
--- a/screenlogicpy/requests/config.py
+++ b/screenlogicpy/requests/config.py
@@ -123,19 +123,20 @@ def decode_pool_config(buff: bytes, data: dict) -> dict:
     colorCount, offset = getSome("I", buff, offset)
     controller_config[VALUE.COLOR_COUNT] = colorCount
 
-    color: list = controller_config.setdefault(GROUP.COLOR, [])
+    colors = []
 
     for i in range(colorCount):
         colorName, offset = getString(buff, offset)
         rgbR, offset = getSome("I", buff, offset)
         rgbG, offset = getSome("I", buff, offset)
         rgbB, offset = getSome("I", buff, offset)
-        color.append(
+        colors.append(
             {
                 ATTR.NAME: colorName,
                 ATTR.VALUE: (rgbR, rgbG, rgbB),
             }
         )
+    controller_config[GROUP.COLOR] = colors
 
     pump_count = 8
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -33,6 +33,10 @@ def test_decode_config(buffer, expected):
 
     assert data == expected
 
+    decode_pool_config(buffer, data)
+
+    assert data == expected
+
 
 @pytest.mark.parametrize(
     "buffer, expected",


### PR DESCRIPTION
Color list was being appended to on each update of the pool config. This caused the list to grow considerably in situations where screenlogicpy had to frequently reconnect to the protocol adapter.

Color list is now reset on each config update.