### PR TITLE
Add remote ScreenLogic connection support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ license-files = [
 ]
 dependencies = [
     "async_timeout>=3.0.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.urls]

--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -124,6 +124,8 @@ class ScreenLogicGateway:
         gsubtype=None,
         name=None,
         connection_closed_callback: Callable = None,
+        password: str | None = None,
+        remote: bool = False,
     ) -> bool:
         """Connect to the ScreenLogic protocol adapter"""
         if self.is_connected:
@@ -147,6 +149,8 @@ class ScreenLogicGateway:
             self._port,
             self._common_connection_closed_callback,
             self._max_retries,
+            password=password,
+            remote=remote,
         )
         if connectPkg:
             self._transport, self._protocol, self._mac = connectPkg

--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -52,6 +52,8 @@ class ScreenLogicGateway:
         self._type = 0
         self._subtype = 0
         self._name = "Unnamed-Screenlogic-Gateway"
+        self._password = None
+        self._remote = False
         self._mac = ""
         self._version = ""
         self._transport: asyncio.Transport = None
@@ -136,6 +138,8 @@ class ScreenLogicGateway:
         self._type = gtype if gtype is not None else self._type
         self._subtype = gsubtype if gsubtype is not None else self._subtype
         self._name = name if name is not None else self._name
+        self._password = password if password is not None else self._password
+        self._remote = remote if remote is not None else self._remote
         self._custom_connection_closed_callback = connection_closed_callback
 
         if not self._ip:
@@ -149,8 +153,8 @@ class ScreenLogicGateway:
             self._port,
             self._common_connection_closed_callback,
             self._max_retries,
-            password=password,
-            remote=remote,
+            password=self._password,
+            remote=self._remote,
         )
         if connectPkg:
             self._transport, self._protocol, self._mac = connectPkg

--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -130,9 +130,6 @@ class ScreenLogicGateway:
         remote: bool | None = None,
     ) -> bool:
         """Connect to the ScreenLogic protocol adapter"""
-        if self.is_connected:
-            return True
-
         self._ip = ip if ip is not None else self._ip
         self._port = port if port is not None else self._port
         self._type = gtype if gtype is not None else self._type
@@ -141,6 +138,9 @@ class ScreenLogicGateway:
         self._password = password if password is not None else self._password
         self._remote = remote if remote is not None else self._remote
         self._custom_connection_closed_callback = connection_closed_callback
+
+        if self.is_connected:
+            return True
 
         if not self._ip:
             raise ScreenLogicError(

--- a/screenlogicpy/gateway.py
+++ b/screenlogicpy/gateway.py
@@ -127,7 +127,7 @@ class ScreenLogicGateway:
         name=None,
         connection_closed_callback: Callable = None,
         password: str | None = None,
-        remote: bool = False,
+        remote: bool | None = None,
     ) -> bool:
         """Connect to the ScreenLogic protocol adapter"""
         if self.is_connected:

--- a/screenlogicpy/requests/__init__.py
+++ b/screenlogicpy/requests/__init__.py
@@ -14,3 +14,5 @@ from .pump import async_request_pump_status
 from .status import async_request_pool_status
 from .scg import async_request_scg_config, async_request_set_scg_config
 from .request import async_make_request
+
+from .remote import RemoteGatewayInfo, async_resolve_remote_gateway

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -9,19 +9,9 @@ from ..const.common import ScreenLogicConnectionError
 from ..const.msg import CODE, COM_MAX_RETRIES, COM_TIMEOUT
 from .protocol import ScreenLogicProtocol
 from .request import async_make_request
-from .utility import asyncio_timeout, decodeMessageString, encodeMessageString
+from .utility import asyncio_timeout, decodeMessageString, encodeMessageBytes, encodeMessageString
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _encode_sl_array(value: bytes) -> bytes:
-    """Encode a ScreenLogic byte array with a length prefix and 4-byte alignment padding.
-
-    Similar to encodeMessageString in utility.py, but operates on raw bytes rather
-    than a string, so it is used for the encrypted password block in remote login.
-    """
-    pad = (4 - len(value) % 4) % 4
-    return struct.pack("<i", len(value)) + value + (b"\x00" * pad)
 
 
 def _zero_pad_to_block(value: str) -> bytes:
@@ -66,7 +56,7 @@ def create_login_message(
         raise ValueError("password and challenge must be provided together")
 
     if password is not None and challenge is not None:
-        passwd = _encode_sl_array(_encrypt_password_first_block(password, challenge))
+        passwd = encodeMessageBytes(_encrypt_password_first_block(password, challenge))
     else:
         local_password = "0000000000000000"  # passwd must be <= 16 chars. empty is not OK.
         passwd = encodeMessageString(local_password)

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -59,6 +59,9 @@ def create_login_message(
     )
     pid = 2
 
+    if (password is None) != (challenge is None):
+        raise ValueError("password and challenge must be provided together")
+
     if password is not None and challenge is not None:
         passwd = _encode_sl_array(_encrypt_password_first_block(password, challenge))
     else:

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -3,6 +3,8 @@ import logging
 import struct
 from typing import Callable
 
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
 from ..const.common import ScreenLogicConnectionError
 from ..const.msg import CODE, COM_MAX_RETRIES, COM_TIMEOUT
 from .protocol import ScreenLogicProtocol
@@ -12,14 +14,57 @@ from .utility import asyncio_timeout, decodeMessageString, encodeMessageString
 _LOGGER = logging.getLogger(__name__)
 
 
-def create_login_message() -> bytes:
+def _slack_for_alignment(length: int) -> int:
+    """Return ScreenLogic padding for 4-byte alignment."""
+    return (4 - length % 4) % 4
+
+
+def _encode_sl_array(value: bytes) -> bytes:
+    """Encode a ScreenLogic byte array."""
+    return struct.pack("<i", len(value)) + value + (b"\x00" * _slack_for_alignment(len(value)))
+
+
+def _zero_pad_to_block(value: str) -> bytes:
+    """Zero-pad a string to an AES block boundary."""
+    raw = value.encode("latin-1")
+    blocks = ((len(raw) // 16) + (1 if len(raw) % 16 else 0)) * 16
+    if blocks == 0:
+        blocks = 16
+    return raw + (b"\x00" * (blocks - len(raw)))
+
+
+def _encrypt_password_first_block(password: str, challenge: str) -> bytes:
+    """Encrypt the remote password challenge.
+
+    ScreenLogic remote login matches node-screenlogic behavior:
+    AES-ECB with a zero-padded password key and zero-padded challenge plaintext,
+    with only the first encrypted block sent in the login message.
+    """
+    key = _zero_pad_to_block(password)
+    plaintext = _zero_pad_to_block(challenge)
+
+    encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+    encrypted = encryptor.update(plaintext) + encryptor.finalize()
+    return encrypted[:16]
+
+
+def create_login_message(
+    password: str | None = None, challenge: str | None = None
+) -> bytes:
     # these constants are only for this message.
     schema = 348
     connectionType = 0
-    clientVersion = encodeMessageString("Android")
+    clientVersion = encodeMessageString(
+        "node-screenlogic" if password is not None and challenge is not None else "Android"
+    )
     pid = 2
-    password = "0000000000000000"  # passwd must be <= 16 chars. empty is not OK.
-    passwd = encodeMessageString(password)
+
+    if password is not None and challenge is not None:
+        passwd = _encode_sl_array(_encrypt_password_first_block(password, challenge))
+    else:
+        local_password = "0000000000000000"  # passwd must be <= 16 chars. empty is not OK.
+        passwd = encodeMessageString(local_password)
+
     fmt = f"<II{len(clientVersion)}s{len(passwd)}sxI"
     return struct.pack(fmt, schema, connectionType, clientVersion, passwd, pid)
 
@@ -85,11 +130,19 @@ async def async_gateway_connect(
     )
 
 
-async def async_gateway_login(protocol: ScreenLogicProtocol, max_retries: int) -> bool:
+async def async_gateway_login(
+    protocol: ScreenLogicProtocol,
+    max_retries: int,
+    password: str | None = None,
+    challenge: str | None = None,
+) -> bool:
     _LOGGER.debug("Logging in")
     return (
         await async_make_request(
-            protocol, CODE.LOCALLOGIN_QUERY, create_login_message(), max_retries
+            protocol,
+            CODE.LOCALLOGIN_QUERY,
+            create_login_message(password, challenge),
+            max_retries,
         )
         is not None
     )
@@ -100,10 +153,18 @@ async def async_connect_to_gateway(
     gateway_port,
     connection_lost_callback: Callable = None,
     max_retries: int = COM_MAX_RETRIES,
-) -> tuple[asyncio.Transport, ScreenLogicProtocol, str]:
+    password: str | None = None,
+    remote: bool = False,
+) -> tuple[asyncio.Transport, ScreenLogicProtocol, str] | None:
     transport, protocol = await async_create_connection(
         gateway_ip, gateway_port, connection_lost_callback
     )
     mac_address = await async_gateway_connect(transport, protocol, max_retries)
-    if await async_gateway_login(protocol, max_retries):
+    challenge = mac_address if remote else None
+
+    if await async_gateway_login(protocol, max_retries, password, challenge):
         return transport, protocol, mac_address
+
+    if transport and not transport.is_closing():
+        transport.close()
+    return None

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -14,14 +14,10 @@ from .utility import asyncio_timeout, decodeMessageString, encodeMessageString
 _LOGGER = logging.getLogger(__name__)
 
 
-def _slack_for_alignment(length: int) -> int:
-    """Return ScreenLogic padding for 4-byte alignment."""
-    return (4 - length % 4) % 4
-
-
 def _encode_sl_array(value: bytes) -> bytes:
-    """Encode a ScreenLogic byte array."""
-    return struct.pack("<i", len(value)) + value + (b"\x00" * _slack_for_alignment(len(value)))
+    """Encode a ScreenLogic byte array with 4-byte alignment padding."""
+    pad = (4 - len(value) % 4) % 4
+    return struct.pack("<i", len(value)) + value + (b"\x00" * pad)
 
 
 def _zero_pad_to_block(value: str) -> bytes:

--- a/screenlogicpy/requests/login.py
+++ b/screenlogicpy/requests/login.py
@@ -15,7 +15,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _encode_sl_array(value: bytes) -> bytes:
-    """Encode a ScreenLogic byte array with 4-byte alignment padding."""
+    """Encode a ScreenLogic byte array with a length prefix and 4-byte alignment padding.
+
+    Similar to encodeMessageString in utility.py, but operates on raw bytes rather
+    than a string, so it is used for the encrypted password block in remote login.
+    """
     pad = (4 - len(value) % 4) % 4
     return struct.pack("<i", len(value)) + value + (b"\x00" * pad)
 
@@ -50,6 +54,9 @@ def create_login_message(
     # these constants are only for this message.
     schema = 348
     connectionType = 0
+    # The remote gateway uses the clientVersion string to select its auth path.
+    # "node-screenlogic" triggers challenge/response authentication; "Android"
+    # triggers the legacy local login flow with a fixed dummy password.
     clientVersion = encodeMessageString(
         "node-screenlogic" if password is not None and challenge is not None else "Android"
     )

--- a/screenlogicpy/requests/remote.py
+++ b/screenlogicpy/requests/remote.py
@@ -1,0 +1,116 @@
+"""Remote dispatcher support for Pentair ScreenLogic."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import struct
+
+from ..const.common import ScreenLogicConnectionError
+
+
+DISPATCHER_HOST = "screenlogicserver.pentair.com"
+DISPATCHER_PORT = 500
+
+ACTION_GATEWAY_REQUEST = 18003
+ACTION_GATEWAY_RESPONSE = 18004
+
+
+@dataclass(slots=True)
+class RemoteGatewayInfo:
+    """Remote dispatcher response."""
+
+    gateway_found: bool
+    license_ok: bool
+    ip_addr: str
+    port: int
+    port_open: bool
+    relay_on: bool
+
+
+def _slack_for_alignment(length: int) -> int:
+    """Return ScreenLogic padding for 4-byte alignment."""
+    return (4 - length % 4) % 4
+
+
+def _sl_string(value: str) -> bytes:
+    """Encode a ScreenLogic string."""
+    data = value.encode("latin-1")
+    return struct.pack("<i", len(data)) + data + (b"\x00" * _slack_for_alignment(len(data)))
+
+
+def _read_sl_string(payload: bytes, offset: int) -> tuple[str, int]:
+    """Decode a ScreenLogic string from payload at offset."""
+    (length,) = struct.unpack_from("<i", payload, offset)
+    offset += 4
+    value = payload[offset : offset + length].decode("latin-1")
+    offset += length + _slack_for_alignment(length)
+    return value, offset
+
+
+def _make_message(action: int, payload: bytes = b"", sender_id: int = 0) -> bytes:
+    """Create a ScreenLogic protocol message."""
+    return struct.pack("<HHi", sender_id, action, len(payload)) + payload
+
+
+async def _read_exact(reader: asyncio.StreamReader, length: int) -> bytes:
+    """Read exactly length bytes."""
+    return await reader.readexactly(length)
+
+
+async def _read_message(reader: asyncio.StreamReader) -> tuple[int, int, bytes]:
+    """Read one ScreenLogic protocol message."""
+    header = await _read_exact(reader, 8)
+    sender_id, action, payload_len = struct.unpack("<HHi", header)
+    payload = await _read_exact(reader, payload_len) if payload_len else b""
+    return sender_id, action, payload
+
+
+async def async_resolve_remote_gateway(system_name: str) -> RemoteGatewayInfo:
+    """Resolve a ScreenLogic system name through Pentair's remote dispatcher.
+
+    Example system name format: "Pentair: 12-AB-34".
+    """
+    try:
+        reader, writer = await asyncio.open_connection(DISPATCHER_HOST, DISPATCHER_PORT)
+    except OSError as ex:
+        raise ScreenLogicConnectionError(
+            f"Failed to connect to remote dispatcher at {DISPATCHER_HOST}:{DISPATCHER_PORT}"
+        ) from ex
+
+    try:
+        payload = _sl_string(system_name) + _sl_string(system_name)
+        writer.write(_make_message(ACTION_GATEWAY_REQUEST, payload))
+        await writer.drain()
+
+        _sender_id, action, response = await _read_message(reader)
+        if action != ACTION_GATEWAY_RESPONSE:
+            raise ScreenLogicConnectionError(
+                f"Unexpected remote dispatcher response action {action}"
+            )
+
+        offset = 0
+        gateway_found = response[offset] != 0
+        offset += 1
+        license_ok = response[offset] != 0
+        offset += 1
+        ip_addr, offset = _read_sl_string(response, offset)
+        (port,) = struct.unpack_from("<H", response, offset)
+        offset += 2
+        port_open = response[offset] != 0
+        offset += 1
+        relay_on = response[offset] != 0
+
+        return RemoteGatewayInfo(
+            gateway_found=gateway_found,
+            license_ok=license_ok,
+            ip_addr=ip_addr,
+            port=port,
+            port_open=port_open,
+            relay_on=relay_on,
+        )
+    except (asyncio.IncompleteReadError, OSError) as ex:
+        raise ScreenLogicConnectionError("Failed to read remote dispatcher response") from ex
+    finally:
+        writer.close()
+        await writer.wait_closed()

--- a/screenlogicpy/requests/remote.py
+++ b/screenlogicpy/requests/remote.py
@@ -2,22 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
-import struct
 
 from ..const.common import ScreenLogicConnectionError
-from ..const.msg import HEADER_FORMAT, HEADER_LENGTH
-from .utility import encodeMessageString, getString, makeMessage
+from ..const.msg import CODE, COM_MAX_RETRIES
+from .login import async_create_connection
+from .protocol import ScreenLogicProtocol
+from .request import async_make_request
+from .utility import encodeMessageString, getSome, getString
 
 
 DISPATCHER_HOST = "screenlogicserver.pentair.com"
 DISPATCHER_PORT = 500
-
-# Action codes for the Pentair remote dispatcher protocol.
-# These are fixed values defined by the ScreenLogic protocol.
-ACTION_GATEWAY_REQUEST = 18003
-ACTION_GATEWAY_RESPONSE = 18004
 
 
 @dataclass(slots=True)
@@ -32,73 +28,72 @@ class RemoteGatewayInfo:
     relay_on: bool
 
 
-async def _read_message(reader: asyncio.StreamReader) -> tuple[int, int, bytes]:
-    """Read one ScreenLogic protocol message from a raw stream.
+async def async_request_remote_gateway(
+    protocol: ScreenLogicProtocol, system_name: str, max_retries: int
+) -> bytes:
+    """Send a gateway-data request to the remote dispatcher and return raw response bytes.
 
-    The remote dispatcher is contacted via a plain asyncio TCP connection
-    rather than through ScreenLogicProtocol, so we read the wire format
-    directly here instead of going through the normal request machinery.
-    """
-    header = await reader.readexactly(HEADER_LENGTH)
-    sender_id, action, payload_len = struct.unpack_from(HEADER_FORMAT, header)
-    payload = await reader.readexactly(payload_len) if payload_len else b""
-    return sender_id, action, payload
-
-
-async def async_resolve_remote_gateway(system_name: str) -> RemoteGatewayInfo:
-    """Resolve a ScreenLogic system name through Pentair's remote dispatcher.
+    The dispatcher request payload contains the system name twice, once as the
+    gatewayType field and once as the gatewayName field, matching the wire format
+    expected by Pentair's remote dispatcher.
 
     Example system name format: "Pentair: 12-AB-34".
     """
-    try:
-        reader, writer = await asyncio.open_connection(DISPATCHER_HOST, DISPATCHER_PORT)
-    except OSError as ex:
-        raise ScreenLogicConnectionError(
-            f"Failed to connect to remote dispatcher at {DISPATCHER_HOST}:{DISPATCHER_PORT}"
-        ) from ex
+    payload = encodeMessageString(system_name) + encodeMessageString(system_name)
+    return await async_make_request(
+        protocol, CODE.GATEWAYDATA_QUERY, payload, max_retries
+    )
 
-    try:
-        # The dispatcher request payload contains the system name twice:
-        # once as the gatewayType field and once as the gatewayName field.
-        payload = encodeMessageString(system_name) + encodeMessageString(system_name)
-        writer.write(makeMessage(0, ACTION_GATEWAY_REQUEST, payload))
-        await writer.drain()
 
-        _sender_id, action, response = await _read_message(reader)
-        if action != ACTION_GATEWAY_RESPONSE:
+def decode_remote_gateway(buff: bytes) -> RemoteGatewayInfo:
+    """Decode a raw dispatcher response buffer into a RemoteGatewayInfo.
+
+    Dispatcher response wire layout:
+      1 byte  - gateway_found (bool)
+      1 byte  - license_ok (bool)
+      string  - ip_addr (ScreenLogic length-prefixed, 4-byte aligned)
+      2 bytes - port (uint16, little-endian)
+      1 byte  - port_open (bool)
+      1 byte  - relay_on (bool)
+    """
+    gateway_found, offset = getSome("B", buff, 0)
+    license_ok, offset = getSome("B", buff, offset)
+    ip_addr, offset = getString(buff, offset)
+    port, offset = getSome("H", buff, offset)
+    port_open, offset = getSome("B", buff, offset)
+    relay_on, offset = getSome("B", buff, offset)
+
+    return RemoteGatewayInfo(
+        gateway_found=bool(gateway_found),
+        license_ok=bool(license_ok),
+        ip_addr=ip_addr,
+        port=port,
+        port_open=bool(port_open),
+        relay_on=bool(relay_on),
+    )
+
+
+async def async_resolve_remote_gateway(
+    system_name: str, max_retries: int = COM_MAX_RETRIES
+) -> RemoteGatewayInfo:
+    """Resolve a ScreenLogic system name through Pentair's remote dispatcher.
+
+    Connects to the Pentair remote dispatcher, sends a GATEWAYDATA_QUERY for
+    the given system name, and returns the parsed RemoteGatewayInfo. The
+    dispatcher uses the same ScreenLogic binary message protocol as the pool
+    gateway, so the standard ScreenLogicProtocol and async_make_request
+    machinery are used directly.
+
+    Example system name format: "Pentair: 12-AB-34".
+    """
+    transport, protocol = await async_create_connection(DISPATCHER_HOST, DISPATCHER_PORT)
+    try:
+        result = await async_request_remote_gateway(protocol, system_name, max_retries)
+        if result is None:
             raise ScreenLogicConnectionError(
-                f"Unexpected remote dispatcher response action {action}"
+                "No response from remote dispatcher"
             )
-
-        # Dispatcher response wire layout:
-        #   1 byte  - gateway_found (bool)
-        #   1 byte  - license_ok (bool)
-        #   string  - ip_addr (ScreenLogic length-prefixed, 4-byte aligned)
-        #   2 bytes - port (uint16, little-endian)
-        #   1 byte  - port_open (bool)
-        #   1 byte  - relay_on (bool)
-        offset = 0
-        gateway_found = response[offset] != 0
-        offset += 1
-        license_ok = response[offset] != 0
-        offset += 1
-        ip_addr, offset = getString(response, offset)
-        (port,) = struct.unpack_from("<H", response, offset)
-        offset += 2
-        port_open = response[offset] != 0
-        offset += 1
-        relay_on = response[offset] != 0
-
-        return RemoteGatewayInfo(
-            gateway_found=gateway_found,
-            license_ok=license_ok,
-            ip_addr=ip_addr,
-            port=port,
-            port_open=port_open,
-            relay_on=relay_on,
-        )
-    except (asyncio.IncompleteReadError, OSError) as ex:
-        raise ScreenLogicConnectionError("Failed to read remote dispatcher response") from ex
+        return decode_remote_gateway(result)
     finally:
-        writer.close()
-        await writer.wait_closed()
+        if transport and not transport.is_closing():
+            transport.close()

--- a/screenlogicpy/requests/remote.py
+++ b/screenlogicpy/requests/remote.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 import struct
 
 from ..const.common import ScreenLogicConnectionError
+from ..const.msg import HEADER_FORMAT, HEADER_LENGTH
+from .utility import encodeMessageString, getString, makeMessage
 
 
 DISPATCHER_HOST = "screenlogicserver.pentair.com"
@@ -28,41 +30,11 @@ class RemoteGatewayInfo:
     relay_on: bool
 
 
-def _slack_for_alignment(length: int) -> int:
-    """Return ScreenLogic padding for 4-byte alignment."""
-    return (4 - length % 4) % 4
-
-
-def _sl_string(value: str) -> bytes:
-    """Encode a ScreenLogic string."""
-    data = value.encode("latin-1")
-    return struct.pack("<i", len(data)) + data + (b"\x00" * _slack_for_alignment(len(data)))
-
-
-def _read_sl_string(payload: bytes, offset: int) -> tuple[str, int]:
-    """Decode a ScreenLogic string from payload at offset."""
-    (length,) = struct.unpack_from("<i", payload, offset)
-    offset += 4
-    value = payload[offset : offset + length].decode("latin-1")
-    offset += length + _slack_for_alignment(length)
-    return value, offset
-
-
-def _make_message(action: int, payload: bytes = b"", sender_id: int = 0) -> bytes:
-    """Create a ScreenLogic protocol message."""
-    return struct.pack("<HHi", sender_id, action, len(payload)) + payload
-
-
-async def _read_exact(reader: asyncio.StreamReader, length: int) -> bytes:
-    """Read exactly length bytes."""
-    return await reader.readexactly(length)
-
-
 async def _read_message(reader: asyncio.StreamReader) -> tuple[int, int, bytes]:
     """Read one ScreenLogic protocol message."""
-    header = await _read_exact(reader, 8)
-    sender_id, action, payload_len = struct.unpack("<HHi", header)
-    payload = await _read_exact(reader, payload_len) if payload_len else b""
+    header = await reader.readexactly(HEADER_LENGTH)
+    sender_id, action, payload_len = struct.unpack_from(HEADER_FORMAT, header)
+    payload = await reader.readexactly(payload_len) if payload_len else b""
     return sender_id, action, payload
 
 
@@ -79,8 +51,8 @@ async def async_resolve_remote_gateway(system_name: str) -> RemoteGatewayInfo:
         ) from ex
 
     try:
-        payload = _sl_string(system_name) + _sl_string(system_name)
-        writer.write(_make_message(ACTION_GATEWAY_REQUEST, payload))
+        payload = encodeMessageString(system_name) + encodeMessageString(system_name)
+        writer.write(makeMessage(0, ACTION_GATEWAY_REQUEST, payload))
         await writer.drain()
 
         _sender_id, action, response = await _read_message(reader)
@@ -94,7 +66,7 @@ async def async_resolve_remote_gateway(system_name: str) -> RemoteGatewayInfo:
         offset += 1
         license_ok = response[offset] != 0
         offset += 1
-        ip_addr, offset = _read_sl_string(response, offset)
+        ip_addr, offset = getString(response, offset)
         (port,) = struct.unpack_from("<H", response, offset)
         offset += 2
         port_open = response[offset] != 0

--- a/screenlogicpy/requests/remote.py
+++ b/screenlogicpy/requests/remote.py
@@ -14,6 +14,8 @@ from .utility import encodeMessageString, getString, makeMessage
 DISPATCHER_HOST = "screenlogicserver.pentair.com"
 DISPATCHER_PORT = 500
 
+# Action codes for the Pentair remote dispatcher protocol.
+# These are fixed values defined by the ScreenLogic protocol.
 ACTION_GATEWAY_REQUEST = 18003
 ACTION_GATEWAY_RESPONSE = 18004
 
@@ -31,7 +33,12 @@ class RemoteGatewayInfo:
 
 
 async def _read_message(reader: asyncio.StreamReader) -> tuple[int, int, bytes]:
-    """Read one ScreenLogic protocol message."""
+    """Read one ScreenLogic protocol message from a raw stream.
+
+    The remote dispatcher is contacted via a plain asyncio TCP connection
+    rather than through ScreenLogicProtocol, so we read the wire format
+    directly here instead of going through the normal request machinery.
+    """
     header = await reader.readexactly(HEADER_LENGTH)
     sender_id, action, payload_len = struct.unpack_from(HEADER_FORMAT, header)
     payload = await reader.readexactly(payload_len) if payload_len else b""
@@ -51,6 +58,8 @@ async def async_resolve_remote_gateway(system_name: str) -> RemoteGatewayInfo:
         ) from ex
 
     try:
+        # The dispatcher request payload contains the system name twice:
+        # once as the gatewayType field and once as the gatewayName field.
         payload = encodeMessageString(system_name) + encodeMessageString(system_name)
         writer.write(makeMessage(0, ACTION_GATEWAY_REQUEST, payload))
         await writer.drain()
@@ -61,6 +70,13 @@ async def async_resolve_remote_gateway(system_name: str) -> RemoteGatewayInfo:
                 f"Unexpected remote dispatcher response action {action}"
             )
 
+        # Dispatcher response wire layout:
+        #   1 byte  - gateway_found (bool)
+        #   1 byte  - license_ok (bool)
+        #   string  - ip_addr (ScreenLogic length-prefixed, 4-byte aligned)
+        #   2 bytes - port (uint16, little-endian)
+        #   1 byte  - port_open (bool)
+        #   1 byte  - relay_on (bool)
         offset = 0
         gateway_found = response[offset] != 0
         offset += 1

--- a/screenlogicpy/requests/utility.py
+++ b/screenlogicpy/requests/utility.py
@@ -67,6 +67,19 @@ def encodeMessageString(string: str, utf_16: bool = False) -> bytes:
     return struct.pack(fmt, length, data)
 
 
+def encodeMessageBytes(data: bytes) -> bytes:
+    """Returns a ScreenLogic length-prefixed, 4-byte-aligned byte buffer.
+
+    Equivalent to encodeMessageString but operates on raw bytes rather than a
+    string. Used when the payload is already binary (e.g. an encrypted block).
+    """
+    length = len(data)
+    over = length % 4
+    pad = (4 - over) if over > 0 else 0  # pad to multiple of 4
+    fmt = f"<I{length + pad}s"
+    return struct.pack(fmt, length, data)
+
+
 def decodeMessageString(data) -> str:
     encoding = "utf-8"
     size = struct.unpack_from("<I", data, 0)[0]

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,107 @@
+"""Tests for screenlogicpy/requests/remote.py."""
+
+import struct
+
+import pytest
+
+from screenlogicpy.requests.remote import RemoteGatewayInfo, decode_remote_gateway
+from screenlogicpy.requests.utility import encodeMessageString
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_dispatcher_response(
+    gateway_found: bool,
+    license_ok: bool,
+    ip_addr: str,
+    port: int,
+    port_open: bool,
+    relay_on: bool,
+) -> bytes:
+    """Construct a synthetic dispatcher response buffer matching the wire format."""
+    buf = struct.pack("BB", int(gateway_found), int(license_ok))
+    buf += encodeMessageString(ip_addr)
+    buf += struct.pack("<HBB", port, int(port_open), int(relay_on))
+    return buf
+
+
+# ---------------------------------------------------------------------------
+# decode_remote_gateway tests
+# ---------------------------------------------------------------------------
+
+def test_decode_remote_gateway_found():
+    """Successful gateway lookup populates all fields correctly."""
+    buf = _build_dispatcher_response(
+        gateway_found=True,
+        license_ok=True,
+        ip_addr="192.168.1.50",
+        port=80,
+        port_open=True,
+        relay_on=False,
+    )
+    info = decode_remote_gateway(buf)
+    assert isinstance(info, RemoteGatewayInfo)
+    assert info.gateway_found is True
+    assert info.license_ok is True
+    assert info.ip_addr == "192.168.1.50"
+    assert info.port == 80
+    assert info.port_open is True
+    assert info.relay_on is False
+
+
+def test_decode_remote_gateway_not_found():
+    """Dispatcher reports gateway not found — all flags false, port zero."""
+    buf = _build_dispatcher_response(
+        gateway_found=False,
+        license_ok=False,
+        ip_addr="0.0.0.0",
+        port=0,
+        port_open=False,
+        relay_on=False,
+    )
+    info = decode_remote_gateway(buf)
+    assert info.gateway_found is False
+    assert info.license_ok is False
+    assert info.port == 0
+
+
+def test_decode_remote_gateway_relay_on():
+    """relay_on flag is decoded correctly when set."""
+    buf = _build_dispatcher_response(
+        gateway_found=True,
+        license_ok=True,
+        ip_addr="10.0.0.1",
+        port=8080,
+        port_open=True,
+        relay_on=True,
+    )
+    info = decode_remote_gateway(buf)
+    assert info.relay_on is True
+    assert info.port == 8080
+
+
+def test_decode_remote_gateway_non_standard_port():
+    """Non-standard port values round-trip correctly."""
+    for port in (443, 1024, 65535):
+        buf = _build_dispatcher_response(True, True, "1.2.3.4", port, True, False)
+        info = decode_remote_gateway(buf)
+        assert info.port == port, f"port {port} did not round-trip"
+
+
+def test_decode_remote_gateway_returns_bools():
+    """Boolean fields are Python bools, not raw ints."""
+    buf = _build_dispatcher_response(True, True, "1.2.3.4", 80, True, False)
+    info = decode_remote_gateway(buf)
+    assert type(info.gateway_found) is bool
+    assert type(info.license_ok) is bool
+    assert type(info.port_open) is bool
+    assert type(info.relay_on) is bool
+
+
+def test_decode_remote_gateway_long_ip():
+    """IP address strings of normal length parse correctly."""
+    buf = _build_dispatcher_response(True, True, "255.255.255.255", 80, True, False)
+    info = decode_remote_gateway(buf)
+    assert info.ip_addr == "255.255.255.255"

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,8 +1,14 @@
-import asyncio
+import struct
 from datetime import datetime, timezone
+
 import pytest
 
-from screenlogicpy.requests.utility import decodeMessageTime, encodeMessageTime
+from screenlogicpy.requests.utility import (
+    decodeMessageTime,
+    encodeMessageBytes,
+    encodeMessageString,
+    encodeMessageTime,
+)
 
 
 def test_encode_decode_time():
@@ -12,3 +18,52 @@ def test_encode_decode_time():
     assert decodeMessageTime(data) == datetime(
         2023, 11, 19, 18, 15, 0, 175000, tzinfo=timezone.utc
     )
+
+
+def test_encode_message_bytes_length_header():
+    """Length field in the 4-byte header matches the raw data length."""
+    data = b"\x01\x02\x03\x04"
+    result = encodeMessageBytes(data)
+    (length,) = struct.unpack_from("<I", result)
+    assert length == 4
+
+
+def test_encode_message_bytes_no_padding_needed():
+    """Input already a multiple of 4 — no padding bytes added."""
+    data = b"A" * 16
+    result = encodeMessageBytes(data)
+    # 4-byte header + 16 bytes data + 0 padding
+    assert len(result) == 20
+
+
+def test_encode_message_bytes_padding_added():
+    """Input not a multiple of 4 — padded up to next multiple."""
+    data = b"A" * 14
+    result = encodeMessageBytes(data)
+    # 4-byte header + 14 bytes data + 2 bytes padding = 20
+    assert len(result) == 20
+    # Padding bytes are zero
+    assert result[-2:] == b"\x00\x00"
+
+
+def test_encode_message_bytes_one_byte_input():
+    """Single byte input is padded to 4 bytes."""
+    result = encodeMessageBytes(b"X")
+    assert len(result) == 8
+    assert result[-3:] == b"\x00\x00\x00"
+
+
+def test_encode_message_bytes_empty():
+    """Empty input produces only the 4-byte length header (length=0)."""
+    result = encodeMessageBytes(b"")
+    assert len(result) == 4
+    (length,) = struct.unpack_from("<I", result)
+    assert length == 0
+
+
+def test_encode_message_bytes_matches_encode_message_string():
+    """encodeMessageBytes on UTF-8 encoded text must match encodeMessageString."""
+    for text in ("Android", "node-screenlogic", "Pentair: 12-AB-34"):
+        assert encodeMessageBytes(text.encode()) == encodeMessageString(text), (
+            f"mismatch for {text!r}"
+        )


### PR DESCRIPTION
## Summary

Adds support for connecting to Pentair ScreenLogic gateways through the remote dispatcher.

This includes:
- Resolving a remote ScreenLogic system name through `screenlogicserver.pentair.com:500`
- Parsing the dispatcher response into `RemoteGatewayInfo`
- Supporting password/challenge-based remote login
- Preserving existing local/passwordless login behavior

## Testing

Tested against a real ScreenLogic remote gateway using environment variables for the system name and password.

Verified:
- Remote dispatcher lookup succeeds
- Remote challenge/password login succeeds
- Gateway version request succeeds
- Full gateway update succeeds
- Existing local login message generation still works

Example local checks:

```text
local login message length: 45
remote login message length: 53

## Notes
This adds cryptography as a runtime dependency for AES password challenge encryption.